### PR TITLE
fix: restore cass tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,6 @@ __debug_bin*
 Thumbs.db
 
 .local/
-.cass/
 .codemap/
 .claude/screenshots/
 .claude/worktrees/


### PR DESCRIPTION
## Summary
- remove the mistaken `.cass/` ignore rule from `.gitignore`
- restore the repo contract that only the diary-style artifacts under `.cass/` stay ignored via `.cass/.gitignore`

## Confirmation
- the `cass` skill describes CASS/CM memory roles
- the repo-specific rule is in `CLAUDE.md`: `Repo-level memory lives in .cass/ (playbook is committed, diary is gitignored).`
- so the top-level `.gitignore` entry was incorrect for this repo

## Verification
- pre-push CI passed (`lint`, `test`, `vet`)

No need to wait for follow-up review on this one; it is a one-line revert of the prior mistake.